### PR TITLE
feat: Add rollback mechanism when training fails

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -71,14 +71,20 @@ def train_model():
     """Train the model using the created dataset."""
     try:
         logger.info("Starting model training...")
-        os.system(
+        # Run training script and capture return code
+        return_code = os.system(
             "python train_model.py --dataset email_dataset.csv --output model_output"
         )
-        logger.info("Model training completed")
-        return True
+        
+        if return_code == 0:
+            logger.info("Model training completed successfully")
+            return True
+        else:
+            logger.warning("Model training failed, will continue without adapter")
+            return False
+            
     except Exception as e:
-        logger.error(f"Failed to train model: {str(e)}")
-        sys.exit(1)
+        logger.warning(f"Failed to train model: {str(e)}, will continue without adapter")
         return False
 
 
@@ -95,12 +101,12 @@ def run_email_bot():
 def run_workflow():
     create_dataset()
     
-    # Try training, exit if failed
-    if not train_model():
-        logger.error("Training failed, stopping workflow")
-        return False
-        
-    # Only run bot if training was successful
+    # Try training, but continue even if it fails
+    training_success = train_model()
+    if not training_success:
+        logger.warning("Training failed, continuing with base model only")
+    
+    # Run bot regardless of training outcome
     run_email_bot()
     return True
 

--- a/lambda.py
+++ b/lambda.py
@@ -75,9 +75,11 @@ def train_model():
             "python train_model.py --dataset email_dataset.csv --output model_output"
         )
         logger.info("Model training completed")
+        return True
     except Exception as e:
         logger.error(f"Failed to train model: {str(e)}")
         sys.exit(1)
+        return False
 
 
 def run_email_bot():
@@ -88,6 +90,19 @@ def run_email_bot():
     except Exception as e:
         logger.error(f"Failed to run email bot: {str(e)}")
         sys.exit(1)
+
+
+def run_workflow():
+    create_dataset()
+    
+    # Try training, exit if failed
+    if not train_model():
+        logger.error("Training failed, stopping workflow")
+        return False
+        
+    # Only run bot if training was successful
+    run_email_bot()
+    return True
 
 
 def main():
@@ -127,9 +142,7 @@ def main():
         elif choice == "3":
             run_email_bot()
         elif choice == "4":
-            create_dataset()
-            train_model()
-            run_email_bot()
+            run_workflow()
         elif choice == "5":
             logger.info("Exiting LAMBDA...")
             break

--- a/lambda_bot.py
+++ b/lambda_bot.py
@@ -41,17 +41,19 @@ class LambdaBot:
 
     def _load_model(self) -> Tuple:
         """Load the appropriate model based on platform and available adapters"""
-
         if config.IS_MAC:
             from mlx_lm import load
-
-            if self.adapter_dir:
-                logging.info(f"Loading model with adapter from: {self.adapter_dir}")
-                model, tokenizer = load(self.model_path, adapter_path=self.adapter_dir)
-            else:
-                logging.info("Loading base model without adapter")
+            try:
+                if self.adapter_dir:
+                    logging.info(f"Loading model with adapter from: {self.adapter_dir}")
+                    model, tokenizer = load(self.model_path, adapter_path=self.adapter_dir)
+                else:
+                    logging.info("Loading base model without adapter")
+                    model, tokenizer = load(self.model_path)
+            except RuntimeError as e:
+                logging.warning(f"Failed to load adapter: {e}")
+                logging.info("Falling back to base model")
                 model, tokenizer = load(self.model_path)
-
         else:
             from transformers import AutoModelForCausalLM, AutoTokenizer
             import torch


### PR DESCRIPTION
## Description
Added a rollback mechanism to handle training failures gracefully. When the training process fails, the system will now:

1. Log the error and stop the workflow
2. Automatically fall back to using the base model
3. Continue with email bot operation using the base model

## Changes Made
- Modified `run_workflow()` function in `lambda.py`
- Added error handling and logging for training failures
- Implemented automatic fallback to base model
- Updated comments to follow English documentation standards

## Testing
- Tested the fallback mechanism with failed training scenarios
- Verified that the email bot continues to function with base model
- Confirmed proper error logging

## Impact
This change improves system reliability by ensuring the email bot can continue operating even when model training fails, rather than stopping the entire workflow.